### PR TITLE
Fix typo in ScanRight doc example ("+" instead of "/")

### DIFF
--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -4970,7 +4970,7 @@ namespace MoreLinq.Extensions
         /// <returns>The scanned sequence.</returns>
         /// <example>
         /// <code><![CDATA[
-        /// var result = Enumerable.Range(1, 5).Select(i => i.ToString()).ScanRight((a, b) => string.Format("({0}/{1})", a, b));
+        /// var result = Enumerable.Range(1, 5).Select(i => i.ToString()).ScanRight((a, b) => $"({a}+{b})");
         /// ]]></code>
         /// The <c>result</c> variable will contain <c>[ "(1+(2+(3+(4+5))))", "(2+(3+(4+5)))", "(3+(4+5))", "(4+5)", "5" ]</c>.
         /// </example>

--- a/MoreLinq/ScanRight.cs
+++ b/MoreLinq/ScanRight.cs
@@ -36,7 +36,7 @@ namespace MoreLinq
         /// <returns>The scanned sequence.</returns>
         /// <example>
         /// <code><![CDATA[
-        /// var result = Enumerable.Range(1, 5).Select(i => i.ToString()).ScanRight((a, b) => string.Format("({0}/{1})", a, b));
+        /// var result = Enumerable.Range(1, 5).Select(i => i.ToString()).ScanRight((a, b) => $"({a}+{b})");
         /// ]]></code>
         /// The <c>result</c> variable will contain <c>[ "(1+(2+(3+(4+5))))", "(2+(3+(4+5)))", "(3+(4+5))", "(4+5)", "5" ]</c>.
         /// </example>


### PR DESCRIPTION
This is a squashed merge of PR #796 that fixes #795.